### PR TITLE
Advice `set-auto-mode-0` instead of `set-auto-mode-1`

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -55,12 +55,12 @@
 (defun guard-lf--enable ()
   "Enable `guard-lf-mode'."
   (advice-add 'find-file-noselect :around #'guard-lf--find-file)
-  (advice-add 'set-auto-mode-1 :around #'guard-lf--set-auto-mode-1))
+  (advice-add 'set-auto-mode-0 :around #'guard-lf--set-auto-mode-0))
 
 (defun guard-lf--disable ()
   "Disable `guard-lf-mode'."
   (advice-remove 'find-file-noselect #'guard-lf--find-file)
-  (advice-remove 'set-auto-mode-1 #'guard-lf--set-auto-mode-1))
+  (advice-remove 'set-auto-mode-0 #'guard-lf--set-auto-mode-0))
 
 ;;;###autoload
 (define-minor-mode guard-lf-mode
@@ -120,8 +120,8 @@ Arguments FNC and ARGS are used to call original operations."
          (guard-lf--detect-large-file (guard-lf-p filename)))
     (apply fnc args)))
 
-(defun guard-lf--set-auto-mode-1 (fnc &rest args)
-  "Advice around the function `set-auto-mode-1'.
+(defun guard-lf--set-auto-mode-0 (fnc &rest args)
+  "Advice around the function `set-auto-mode-0'.
 
 Arguments FNC and ARGS are used to call original operations."
   (when guard-lf--detect-large-file


### PR DESCRIPTION
First, let me thank you for this clever package! I was always annoyed by `so-long` taking too long to open a big file even thought I know that opening the same file in `fundamental-mode` works out of the box. The approach taken by this package makes perfect sens! So thanks!

I've noticed an error displayed when I open a big file with `guard-lf-mode` active, after enabling debug on error I got this trace:

``` emacs-lisp
Debugger entered--Lisp error: (wrong-type-argument consp nil)
  guard-lf--set-auto-mode-1(#<subr set-auto-mode-1>)
  apply(guard-lf--set-auto-mode-1 #<subr set-auto-mode-1> nil)
  set-auto-mode-1()
  so-long--check-header-modes()
  so-long--set-auto-mode(#<subr set-auto-mode>)
  apply(so-long--set-auto-mode #<subr set-auto-mode> nil)
  set-auto-mode()
  normal-mode(t)
  after-find-file(nil t)
  find-file-noselect-1(#<buffer big.js> "~/big.js" nil nil "~/big.js" (73518280 66307))
  #<subr find-file-noselect>("~/big.js" nil nil t)
  apply(#<subr find-file-noselect> ("~/big.js" nil nil t))
  guard-lf--find-file(#<subr find-file-noselect> "~/big.js" nil nil t)
  apply(guard-lf--find-file #<subr find-file-noselect> ("~/big.js" nil nil t))
  #f(advice guard-lf--find-file :around #<subr find-file-noselect>)("~/big.js" nil nil t)
  apply(#f(advice guard-lf--find-file :around #<subr find-file-noselect>) ("~/big.js" nil nil t))
  find-file-noselect("~/big.js" nil nil t)
  find-file("~/big.js" t)
  funcall-interactively(find-file "~/big.js" t)
  command-execute(find-file)
```

It turned out that there was a mistake in the adviced function, `guard-lf` should advice `set-auto-mode-0` instead of `set-auto-mode-1`. Even the signature of `guard-lf--set-auto-mode-1` doesn't match the signature `set-auto-mode-1`.

This PR fixes the issue!