### PR TITLE
 Fix: the `guard-lf-intact-major-modes` where not taken into account 

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -130,7 +130,7 @@ Arguments FNC and ARGS are used to call original operations."
                (not (apply #'provided-mode-derived-p (cons (car args) guard-lf-intact-major-modes))))
       (message "[INFO] Large file detected; use the `%s' as the new major mode"
                guard-lf-major-mode)
-      (setf (nth 0 args) guard-lf-major-mode)))
+      (setcar args guard-lf-major-mode)))
   (apply fnc args))
 
 (provide 'guard-lf)

--- a/guard-lf.el
+++ b/guard-lf.el
@@ -127,7 +127,7 @@ Arguments FNC and ARGS are used to call original operations."
   (when guard-lf--detect-large-file
     (setq guard-lf--detect-large-file nil)  ; Revert back to `nil'
     (when (and guard-lf-major-mode
-               (not (provided-mode-derived-p (nth 0 args) guard-lf-intact-major-modes)))
+               (not (apply #'provided-mode-derived-p (cons (car args) guard-lf-intact-major-modes))))
       (message "[INFO] Large file detected; use the `%s' as the new major mode"
                guard-lf-major-mode)
       (setf (nth 0 args) guard-lf-major-mode)))


### PR DESCRIPTION
This PR fixes the issue mentioned below:

While trying to add some modes (like `pcap-mode`) to `guard-lf-intact-major-modes`, I've noticed that it wasn't taken into account and that the mode was always changed to `fundamental-mode`.

After a quick check, it turned out that `guard-lf-intact-major-modes` wasn't used correctly in `provided-mode-derived-p`, which needs the modes (`&rest modes`) to be provided as separate arguments and not as a list.

The signature of the function:
``` emacs-lisp
(provided-mode-derived-p MODE &rest MODES)
```