### PR TITLE
fix: large file detection breaks on opening directories

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -103,8 +103,9 @@
 ;;;###autoload
 (defun guard-lf-p (filename)
   "Return non-nil if the large FILENAME is detected."
-  (or (guard-lf--file-too-large-p filename)
-      (guard-lf--line-too-long-p filename)))
+  (and (file-regular-p filename)
+       (or (guard-lf--file-too-large-p filename)
+           (guard-lf--line-too-long-p filename))))
 
 ;;
 ;;; Core


### PR DESCRIPTION
This fixes #3 

Calling `guard-lf--file-too-large-p` or `guard-lf--line-too-long-p` on a directory path doesn't make sens. Especially the latter, as it calls the `insert-file-contents` on a directory path, which triggers the `Maximum buffer size exceeded` error.