### PR TITLE
Fix loading large non file-visiting buffers + simplification of the implementation

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -52,36 +52,26 @@
 ;;
 ;;; Entry
 
-(defun guard-lf--enable ()
-  "Enable `guard-lf-mode'."
-  (advice-add 'set-auto-mode-0 :around #'guard-lf--set-auto-mode-0))
-
-(defun guard-lf--disable ()
-  "Disable `guard-lf-mode'."
-  (advice-remove 'set-auto-mode-0 #'guard-lf--set-auto-mode-0))
-
 ;;;###autoload
 (define-minor-mode guard-lf-mode
   "Minor mode `guard-lf-mode'."
   :lighter " Guard-LF"
   :global t
   :group 'guard-lf
-  (if guard-lf-mode (guard-lf--enable) (guard-lf--disable)))
+  (if guard-lf-mode
+      (advice-add 'set-auto-mode-0 :around #'guard-lf--set-auto-mode-0)
+    (advice-remove 'set-auto-mode-0 #'guard-lf--set-auto-mode-0)))
 
 ;;
 ;;; Large File
 
 ;; NOTE: This section is copied around variable `large-file-warning-threshold'.
 
-(defun guard-lf--file-size (filename)
-  "Return the FILENAME size."
-  (when-let (((file-readable-p filename))
-             (attributes (file-attributes filename)))
-    (file-attribute-size attributes)))
-
 (defun guard-lf--file-too-large-p (filename)
   "Return non-nil if FILENAME's size is too large."
-  (when-let ((size (guard-lf--file-size filename)))
+  (when-let (((file-readable-p filename))
+             (attributes (file-attributes filename))
+             (size (file-attribute-size attributes)))
     (and large-file-warning-threshold
          (> size large-file-warning-threshold))))
 

--- a/guard-lf.el
+++ b/guard-lf.el
@@ -67,14 +67,6 @@
 
 ;; NOTE: This section is copied around variable `large-file-warning-threshold'.
 
-(defun guard-lf--file-too-large-p (filename)
-  "Return non-nil if FILENAME's size is too large."
-  (when-let (((file-readable-p filename))
-             (attributes (file-attributes filename))
-             (size (file-attribute-size attributes)))
-    (and large-file-warning-threshold
-         (> size large-file-warning-threshold))))
-
 (defun guard-lf--buffer-too-large-p (buffer)
   "Return non-nil if BUFFER's size is too large."
   (and large-file-warning-threshold
@@ -93,14 +85,7 @@
 ;;; API
 
 ;;;###autoload
-(defun guard-lf-file-p (&optional filename)
-  "Return non-nil if the large FILENAME is detected."
-  (when-let ((filename (or filename (buffer-file-name))))
-    (and (file-regular-p filename)
-         (guard-lf--file-too-large-p filename))))
-
-;;;###autoload
-(defun guard-lf-buffer-p (&optional buffer)
+(defun guard-lf-p (&optional buffer)
   "Return non-nil if the BUFFER is large."
   (when-let ((buffer (or buffer (current-buffer))))
     (or (guard-lf--buffer-too-large-p buffer)
@@ -113,7 +98,7 @@
   "Advice around the function `set-auto-mode-0'.
 
 Arguments FNC and ARGS are used to call original operations."
-  (when (or (guard-lf-file-p) (guard-lf-buffer-p))
+  (when (guard-lf-p)
     (when (and guard-lf-major-mode
                (not (apply #'provided-mode-derived-p (cons (car args) guard-lf-intact-major-modes))))
       (message "[INFO] Large file detected; use the `%s' as the new major mode"

--- a/guard-lf.el
+++ b/guard-lf.el
@@ -87,6 +87,11 @@
     (and large-file-warning-threshold
          (> size large-file-warning-threshold))))
 
+(defun guard-lf--buffer-too-large-p (buffer)
+  "Return non-nil if BUFFER's size is too large."
+  (and large-file-warning-threshold
+       (> (buffer-size buffer) large-file-warning-threshold)))
+
 ;;
 ;;; So long
 
@@ -101,11 +106,18 @@
 ;;; API
 
 ;;;###autoload
-(defun guard-lf-p (filename)
+(defun guard-lf-file-p (&optional filename)
   "Return non-nil if the large FILENAME is detected."
-  (and (file-regular-p filename)
-       (or (guard-lf--file-too-large-p filename)
-           (guard-lf--line-too-long-p filename))))
+  (when-let ((filename (or filename (buffer-file-name))))
+    (and (file-regular-p filename)
+         (or (guard-lf--file-too-large-p filename)
+             (guard-lf--line-too-long-p filename)))))
+
+;;;###autoload
+(defun guard-lf-buffer-p (&optional buffer)
+  "Return non-nil if the BUFFER is large."
+  (when-let ((buffer (or buffer (current-buffer))))
+    (guard-lf--buffer-too-large-p buffer)))
 
 ;;
 ;;; Core
@@ -125,8 +137,7 @@ Arguments FNC and ARGS are used to call original operations."
   "Advice around the function `set-auto-mode-0'.
 
 Arguments FNC and ARGS are used to call original operations."
-  (when guard-lf--detect-large-file
-    (setq guard-lf--detect-large-file nil)  ; Revert back to `nil'
+  (when (or (guard-lf-file-p) (guard-lf-buffer-p))
     (when (and guard-lf-major-mode
                (not (apply #'provided-mode-derived-p (cons (car args) guard-lf-intact-major-modes))))
       (message "[INFO] Large file detected; use the `%s' as the new major mode"


### PR DESCRIPTION
This PR fixes #5 and simplifies the implementation in these manners:

1. There is no need to advice `find-file-noselect`, the file will be opened in all cases, and if we want to check for the /file size/ or for /too long lines/, we can do it inside the `set-auto-mode-0` advice function (using the current buffer and the `(buffer-file-name)`).
2. The current implementation can cause some extra overhead by opening the file to detect too long lines (why we open the file temporarily while we can check for long lines inside `set-auto-mode-0`'s advice?)
3. So, the `guard-lf--line-too-long-p` function has been modified to work on a buffer instead of a file (to avoid opening the file temporarily).

## Edit
I think, by using the `buffer-size` to calculate the current buffer size, we don't even need to get the file size from the file system's attributes. At the `set-auto-mode-0` level, the file would be already inserted in the current buffer, so we can relay on `(buffer-size)`!