### PR TITLE
Enable `guard-lf-large-file-mode` by default (`fundamental-mode` clone)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@
 This is an alternative to Emacs built-in [so-long][].
 
 The [so-long][] package will first enter the major mode and then disable all
-minor modes of your choice. But sometimes, the file is too large, and you
-cannot even exit the event loop. This package takes another approach. It
-prevents you from entering major mode and simply directs you to the basic
-`fundamental-mode`.
+minor modes of your choice. But sometimes, the file is too large, and you cannot
+even exit the event loop. This package takes another approach. It prevents you
+from entering major mode and simply directs you to the mode configured in
+`guard-lf-major-mode` (by default, this is set to `guard-lf-major-mode` which is
+basically the same as `fundamental-mode`).
 
 ## 🔨 Usage
 
@@ -26,7 +27,7 @@ Place the following snippet to your `init.el` file:
 
 ### 🧪 Variables
 
-- `guard-lf-major-mode` - Major mode to use when viewing large file. (Default: `#'fundamental-mode`)
+- `guard-lf-major-mode` - Major mode to use when viewing large file. (Default: `guard-lf-large-file-mode`)
 - `guard-lf-intact-major-modes` - Do nothing for these major modes.
 
 ## 🛠️ Contribute

--- a/guard-lf.el
+++ b/guard-lf.el
@@ -39,7 +39,7 @@
   :group 'tool
   :link '(url-link :tag "Repository" "https://github.com/jcs-elpa/guard-lf"))
 
-(defcustom guard-lf-major-mode #'fundamental-mode
+(defcustom guard-lf-major-mode #'guard-lf-large-file-mode
   "Major mode to use when viewing large file."
   :type 'function
   :group 'guard-lf)
@@ -68,6 +68,10 @@
   (if guard-lf-mode
       (advice-add 'set-auto-mode-0 :around #'guard-lf--set-auto-mode-0)
     (advice-remove 'set-auto-mode-0 #'guard-lf--set-auto-mode-0)))
+
+;; This major mode is basically the same as `fundamental-mode'. It helps users
+;; to distinguish if buffer mode has been set by `guard-lf' or not
+(define-derived-mode guard-lf-large-file-mode fundamental-mode "guard-lf")
 
 ;;
 ;;; Large File
@@ -108,10 +112,10 @@ Arguments FNC and ARGS are used to call original operations."
   (let ((mode (car args)))
     (when (and guard-lf-major-mode
                mode ; nil can be passed for some special modes like `tar-mode'
-               (guard-lf-p)
                (not (apply #'provided-mode-derived-p
-                           (cons mode
-                                 guard-lf-intact-major-modes))))
+                           (append (list mode guard-lf-major-mode)
+                                   guard-lf-intact-major-modes)))
+               (guard-lf-p))
       (message "[guard-lf] Large file detected; using `%s' as major mode instead of `%s'"
                guard-lf-major-mode mode)
       (setcar args guard-lf-major-mode))


### PR DESCRIPTION
This adds the `guard-lf-large-file-mode` and sets it by default in `guard-lf-major-mode`. This can be useful for users to detect if a buffer has been set by `guard-lf` or not.

This can be useful when we run some commands on buffers depending on the current major mode, so when we detect that we are in `guard-lf-large-file-mode`, we know that the current file is considered as a large file.