### PR TITLE
Defer loading `so-long` until needed

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -31,8 +31,6 @@
 
 ;;; Code:
 
-(require 'so-long)
-
 (defgroup guard-lf nil
   "Guard large files."
   :prefix "guard-lf-"
@@ -88,6 +86,7 @@
 
 (defun guard-lf--line-too-long-p (buffer)
   "Return non-nil if BUFFER's line is too long."
+  (require 'so-long)
   (save-excursion
     (with-current-buffer buffer
       (funcall so-long-predicate))))

--- a/guard-lf.el
+++ b/guard-lf.el
@@ -31,6 +31,8 @@
 
 ;;; Code:
 
+(eval-when-compile (require 'so-long))
+
 (defgroup guard-lf nil
   "Guard large files."
   :prefix "guard-lf-"


### PR DESCRIPTION
This package is useful when enabled at startup. However, we might not need to use `so-long-predicate` until a file has been open. So, lets defer loading the `so-long` package.

This is useful for users who want to optimize Emacs' startup time