### PR TITLE
tweak: add more intact modes

### DIFF
--- a/guard-lf.el
+++ b/guard-lf.el
@@ -50,8 +50,12 @@
     archive-mode
     tar-mode
     image-mode
+    hexl-mode
     vlf-mode
-    pcap-mode)
+    pcap-mode
+    pdf-view-mode
+    rosbag-info-mode
+    ein:ipynb-mode)
   "Do nothing for these major modes."
   :type '(repeat symbol)
   :group 'guard-lf)


### PR DESCRIPTION
This commit adds some relevant modes to the intact list.

Modes like the builtin `hexl-mode`, and third-party modes like `pdf-view-mode`, `ein:ipynb-mode` (can contain very long lines, causing `guard-lf` to override it).